### PR TITLE
Phase 10C: Module SDK — factory, registration, discovery, hooks, agent execution

### DIFF
--- a/sdk/discovery/index.ts
+++ b/sdk/discovery/index.ts
@@ -1,0 +1,99 @@
+/**
+ * Module Discovery — discovers installed modules from the filesystem or registry.
+ *
+ * In production, spokestack-core calls discoverModules() at startup to build
+ * the MODULE_REGISTRY used for navigation, agent routing, and canvas rendering.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import type { ModuleManifest, SurfaceDefinition } from '../types/index';
+
+export interface DiscoveredModule {
+  moduleType: string;
+  name: string;
+  version: string;
+  description: string;
+  category: string;
+  minTier: string;
+  tools: string[];
+  surfaces: SurfaceDefinition[];
+  hasContextSchema: boolean;
+  hasCanvasConfig: boolean;
+  hasFlows: boolean;
+}
+
+/**
+ * Scan a modules directory for installed modules.
+ * Reads manifest.json from each subdirectory.
+ */
+export function discoverModules(modulesDir: string): DiscoveredModule[] {
+  if (!fs.existsSync(modulesDir)) return [];
+
+  const entries = fs.readdirSync(modulesDir, { withFileTypes: true });
+  const discovered: DiscoveredModule[] = [];
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const manifestPath = path.join(modulesDir, entry.name, 'manifest.json');
+
+    if (!fs.existsSync(manifestPath)) continue;
+
+    try {
+      const manifest: ModuleManifest = JSON.parse(
+        fs.readFileSync(manifestPath, 'utf-8'),
+      );
+
+      const flowsDir = path.join(modulesDir, entry.name, 'src', 'flows');
+      const hasFlows = fs.existsSync(flowsDir) &&
+        fs.readdirSync(flowsDir).some((f) => f.endsWith('.ts'));
+
+      discovered.push({
+        moduleType: manifest.moduleType,
+        name: manifest.name,
+        version: manifest.version,
+        description: manifest.description,
+        category: manifest.category,
+        minTier: manifest.minTier,
+        tools: manifest.tools,
+        surfaces: manifest.surfaces || [],
+        hasContextSchema: !!manifest.contextSchema,
+        hasCanvasConfig: !!manifest.canvasConfig,
+        hasFlows,
+      });
+    } catch {
+      // Skip unparseable manifests
+    }
+  }
+
+  return discovered;
+}
+
+/**
+ * Build a lookup map from moduleType → DiscoveredModule.
+ */
+export function buildModuleRegistry(
+  modules: DiscoveredModule[],
+): Map<string, DiscoveredModule> {
+  const registry = new Map<string, DiscoveredModule>();
+  for (const mod of modules) {
+    registry.set(mod.moduleType, mod);
+  }
+  return registry;
+}
+
+/**
+ * Get modules available for a given billing tier.
+ */
+export function getModulesForTier(
+  modules: DiscoveredModule[],
+  tier: string,
+): DiscoveredModule[] {
+  const tierOrder = ['FREE', 'STARTER', 'PRO', 'BUSINESS', 'ENTERPRISE'];
+  const tierIdx = tierOrder.indexOf(tier);
+  if (tierIdx === -1) return [];
+  return modules.filter((m) => {
+    const minIdx = tierOrder.indexOf(m.minTier);
+    return minIdx <= tierIdx;
+  });
+}

--- a/sdk/factory/__tests__/factory.test.ts
+++ b/sdk/factory/__tests__/factory.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from 'vitest';
+import { createModule, type ModuleOptions } from '../index';
+import { validateModuleConfig } from '../validate';
+
+const validOptions: ModuleOptions = {
+  id: 'test-module',
+  moduleType: 'CRM',
+  name: 'Test Module',
+  version: '1.0.0',
+  description: 'A test module',
+  category: 'ops',
+  minTier: 'PRO',
+  price: 900,
+  agent: {
+    name: 'test-agent',
+    description: 'Test agent',
+    systemPrompt: 'You are a test agent.',
+    tools: ['createThing', 'listThings'],
+  },
+  tools: ['createThing', 'listThings'],
+  surfaces: [
+    { id: 'test-dashboard', type: 'dashboard', requiredTools: ['listThings'] },
+    { id: 'test-page', type: 'full-page', route: '/test', requiredTools: ['createThing'] },
+  ],
+  migrations: { install: 'migrations/install.ts', uninstall: 'migrations/uninstall.ts' },
+};
+
+describe('createModule', () => {
+  it('produces a valid ModuleBundle', () => {
+    const bundle = createModule(validOptions);
+    expect(bundle.manifest).toBeDefined();
+    expect(bundle.agent).toBeDefined();
+    expect(bundle.manifest.id).toBe('test-module');
+    expect(bundle.manifest.moduleType).toBe('CRM');
+    expect(bundle.agent.name).toBe('test-agent');
+    expect(bundle.agent.system_prompt).toBe('You are a test agent.');
+  });
+
+  it('manifest has correct tool count', () => {
+    const bundle = createModule(validOptions);
+    expect(bundle.manifest.tools).toHaveLength(2);
+  });
+
+  it('manifest has surfaces', () => {
+    const bundle = createModule(validOptions);
+    expect(bundle.manifest.surfaces).toHaveLength(2);
+  });
+
+  it('agent tools match manifest tools', () => {
+    const bundle = createModule(validOptions);
+    expect(bundle.agent.tools).toEqual(bundle.manifest.tools);
+  });
+
+  it('throws on missing id', () => {
+    expect(() => createModule({ ...validOptions, id: '' })).toThrow('id');
+  });
+
+  it('throws on missing moduleType', () => {
+    expect(() => createModule({ ...validOptions, moduleType: '' })).toThrow('moduleType');
+  });
+
+  it('throws on empty tools', () => {
+    expect(() => createModule({ ...validOptions, tools: [] })).toThrow('tool');
+  });
+
+  it('preserves optional fields', () => {
+    const bundle = createModule({
+      ...validOptions,
+      contextSchema: { categoryPrefix: 'test', entityTypes: [], patternTypes: [] },
+      canvasConfig: { nodeType: 'TEST', color: '#FF0000', icon: 'box', entityLabel: 'Test', relationships: [] },
+    });
+    expect(bundle.manifest.contextSchema).toBeDefined();
+    expect(bundle.manifest.canvasConfig?.color).toBe('#FF0000');
+  });
+
+  it('includes handoff triggers in agent definition', () => {
+    const bundle = createModule({
+      ...validOptions,
+      agent: {
+        ...validOptions.agent,
+        handoffTriggers: [
+          { condition: 'deal.value > 50000', targetModule: 'FINANCE', reason: 'High value', contextFields: ['deal.value'] },
+        ],
+      },
+    });
+    expect(bundle.agent.handoffTriggers).toHaveLength(1);
+  });
+
+  it('preserves lifecycle hooks', () => {
+    const onInstall = async () => {};
+    const bundle = createModule({ ...validOptions, hooks: { onInstall } });
+    expect(bundle.hooks?.onInstall).toBe(onInstall);
+  });
+});
+
+describe('validateModuleConfig', () => {
+  it('valid config passes', () => {
+    const result = validateModuleConfig(validOptions);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('rejects missing id', () => {
+    const result = validateModuleConfig({ ...validOptions, id: undefined as any });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('id'))).toBe(true);
+  });
+
+  it('rejects invalid semver', () => {
+    const result = validateModuleConfig({ ...validOptions, version: 'abc' });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('semver'))).toBe(true);
+  });
+
+  it('rejects invalid category', () => {
+    const result = validateModuleConfig({ ...validOptions, category: 'invalid' as any });
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects invalid tier', () => {
+    const result = validateModuleConfig({ ...validOptions, minTier: 'GOLD' });
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects empty tools', () => {
+    const result = validateModuleConfig({ ...validOptions, tools: [] });
+    expect(result.valid).toBe(false);
+  });
+
+  it('validates canvasConfig color format', () => {
+    const result = validateModuleConfig({
+      ...validOptions,
+      canvasConfig: { nodeType: 'T', color: 'red', icon: 'x', entityLabel: 'T', relationships: [] },
+    });
+    expect(result.errors.some(e => e.includes('#RRGGBB'))).toBe(true);
+  });
+});

--- a/sdk/factory/index.ts
+++ b/sdk/factory/index.ts
@@ -1,0 +1,124 @@
+/**
+ * Module Factory — convenience wrapper for creating modules.
+ *
+ * createModule() produces a ModuleManifest + AgentDefinition bundle
+ * from a single options object. It validates required fields and provides
+ * sensible defaults. This is the recommended way to define new modules.
+ *
+ * Usage:
+ *   const myModule = createModule({
+ *     id: 'my-module',
+ *     moduleType: 'CRM',
+ *     name: 'CRM',
+ *     ...
+ *   });
+ */
+
+import type {
+  ModuleManifest,
+  AgentDefinition,
+  SurfaceDefinition,
+  HandoffTrigger,
+  CanvasConfig,
+} from '../types/index';
+import type { ContextSchema } from '../types/context';
+
+export interface ModuleOptions {
+  /** Unique module ID (kebab-case) */
+  id: string;
+  /** Must match a ModuleType enum value from core */
+  moduleType: string;
+  /** Human-readable display name */
+  name: string;
+  /** Semver version */
+  version: string;
+  /** Short description */
+  description: string;
+  /** Module category */
+  category: 'core' | 'marketing' | 'ops' | 'analytics' | 'custom';
+  /** Minimum tier required */
+  minTier: string;
+  /** Price in cents/month (0 for free) */
+  price?: number;
+
+  /** Agent configuration */
+  agent: {
+    name: string;
+    description: string;
+    systemPrompt: string;
+    tools: string[];
+    model?: string;
+    handoffTriggers?: HandoffTrigger[];
+  };
+
+  /** Tool names this module provides */
+  tools: string[];
+  /** UI surface definitions */
+  surfaces: SurfaceDefinition[];
+
+  /** Migration paths */
+  migrations?: { install: string; uninstall: string };
+  /** Context graph contract (Phase 3) */
+  contextSchema?: ContextSchema;
+  /** Canvas config (Phase 4) */
+  canvasConfig?: CanvasConfig;
+
+  /** Lifecycle hooks */
+  hooks?: {
+    onInstall?: () => Promise<void>;
+    onUninstall?: () => Promise<void>;
+    onActivate?: () => Promise<void>;
+    onDeactivate?: () => Promise<void>;
+  };
+}
+
+export interface ModuleBundle {
+  manifest: ModuleManifest;
+  agent: AgentDefinition;
+  hooks?: ModuleOptions['hooks'];
+}
+
+/**
+ * Create a module from a single options object.
+ * Validates required fields and produces a ModuleManifest + AgentDefinition.
+ */
+export function createModule(options: ModuleOptions): ModuleBundle {
+  if (!options.id) throw new Error('Module id is required');
+  if (!options.moduleType) throw new Error('Module moduleType is required');
+  if (!options.name) throw new Error('Module name is required');
+  if (!options.agent?.name) throw new Error('Module agent.name is required');
+  if (!options.tools || options.tools.length === 0) {
+    throw new Error('Module must define at least one tool');
+  }
+
+  const manifest: ModuleManifest = {
+    id: options.id,
+    moduleType: options.moduleType,
+    name: options.name,
+    version: options.version,
+    description: options.description,
+    category: options.category,
+    minTier: options.minTier,
+    price: options.price,
+    agentDefinition: {
+      path: `src/agent/${options.id}-agent.ts`,
+      name: options.agent.name,
+    },
+    tools: options.tools,
+    surfaces: options.surfaces,
+    migrations: options.migrations,
+    contextSchema: options.contextSchema,
+    canvasConfig: options.canvasConfig,
+  };
+
+  const agent: AgentDefinition = {
+    name: options.agent.name,
+    description: options.agent.description,
+    system_prompt: options.agent.systemPrompt,
+    tools: options.agent.tools,
+    model: options.agent.model,
+    handoffTriggers: options.agent.handoffTriggers,
+  };
+
+  return { manifest, agent, hooks: options.hooks };
+}

--- a/sdk/factory/validate.ts
+++ b/sdk/factory/validate.ts
@@ -1,0 +1,65 @@
+/**
+ * Module Config Validation — validates ModuleOptions before createModule().
+ * Uses plain TypeScript (no Zod dependency) to keep the SDK lightweight.
+ */
+
+import type { ModuleOptions } from './index';
+
+export interface ConfigValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+const VALID_CATEGORIES = ['core', 'marketing', 'ops', 'analytics', 'custom'];
+const VALID_TIERS = ['FREE', 'STARTER', 'PRO', 'BUSINESS', 'ENTERPRISE'];
+
+export function validateModuleConfig(config: Partial<ModuleOptions>): ConfigValidationResult {
+  const errors: string[] = [];
+
+  if (!config.id || typeof config.id !== 'string') errors.push('id: required string');
+  if (!config.moduleType || typeof config.moduleType !== 'string') errors.push('moduleType: required string');
+  if (!config.name || typeof config.name !== 'string') errors.push('name: required string');
+  if (!config.version || !/^\d+\.\d+\.\d+/.test(config.version)) errors.push('version: must be valid semver');
+  if (!config.description) errors.push('description: required');
+  if (!config.category || !VALID_CATEGORIES.includes(config.category)) {
+    errors.push(`category: must be one of ${VALID_CATEGORIES.join(', ')}`);
+  }
+  if (!config.minTier || !VALID_TIERS.includes(config.minTier)) {
+    errors.push(`minTier: must be one of ${VALID_TIERS.join(', ')}`);
+  }
+
+  // Agent
+  if (!config.agent) {
+    errors.push('agent: required');
+  } else {
+    if (!config.agent.name) errors.push('agent.name: required');
+    if (!config.agent.systemPrompt) errors.push('agent.systemPrompt: required');
+    if (!config.agent.tools || config.agent.tools.length === 0) {
+      errors.push('agent.tools: must have at least one tool');
+    }
+  }
+
+  // Tools
+  if (!config.tools || config.tools.length === 0) {
+    errors.push('tools: must have at least one tool');
+  }
+
+  // Surfaces
+  if (config.surfaces) {
+    for (let i = 0; i < config.surfaces.length; i++) {
+      const s = config.surfaces[i];
+      if (!s.id) errors.push(`surfaces[${i}].id: required`);
+    }
+  }
+
+  // Canvas config
+  if (config.canvasConfig) {
+    const cc = config.canvasConfig;
+    if (!cc.nodeType) errors.push('canvasConfig.nodeType: required');
+    if (!cc.color || !/^#[0-9A-Fa-f]{6}$/.test(cc.color)) errors.push('canvasConfig.color: must be #RRGGBB');
+    if (!cc.icon) errors.push('canvasConfig.icon: required');
+    if (!cc.entityLabel) errors.push('canvasConfig.entityLabel: required');
+  }
+
+  return { valid: errors.length === 0, errors };
+}

--- a/sdk/hooks/index.ts
+++ b/sdk/hooks/index.ts
@@ -1,0 +1,129 @@
+/**
+ * React Hooks for Module Usage — consumed by spokestack-core's dashboard.
+ *
+ * These hooks let module pages interact with agents and access module context.
+ * The actual React components live in spokestack-core — these hooks are
+ * the interface between module definitions and the UI.
+ *
+ * Note: This file uses type-only React references to avoid requiring React
+ * as a dependency in the SDK package. spokestack-core provides the runtime.
+ */
+
+/**
+ * Configuration for module-aware agent execution.
+ * Passed to useModule() by the ModuleProvider in spokestack-core.
+ */
+export interface ModuleContext {
+  moduleType: string;
+  orgId: string;
+  coreApiUrl: string;
+  authToken: string;
+}
+
+/**
+ * Result from an agent execution request.
+ */
+export interface AgentResponse {
+  success: boolean;
+  output?: string;
+  artifacts?: Array<{ type: string; data: unknown }>;
+  error?: string;
+}
+
+/**
+ * Execute an agent request for a specific module context.
+ * Called by spokestack-core's chat panel when a module page is active.
+ */
+export async function executeModuleAgent(
+  ctx: ModuleContext,
+  agentType: string,
+  input: string,
+): Promise<AgentResponse> {
+  try {
+    const res = await fetch(`${ctx.coreApiUrl}/api/v1/agents/ask`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${ctx.authToken}`,
+        'X-Module-Subdomain': ctx.moduleType.toLowerCase(),
+      },
+      body: JSON.stringify({
+        agentType,
+        input,
+        moduleSubdomain: ctx.moduleType.toLowerCase(),
+      }),
+    });
+
+    if (!res.ok) {
+      return { success: false, error: `Agent request failed: ${res.status}` };
+    }
+
+    const data = await res.json();
+    return {
+      success: true,
+      output: data.output || data.text,
+      artifacts: data.artifacts,
+    };
+  } catch (err) {
+    return { success: false, error: (err as Error).message };
+  }
+}
+
+/**
+ * Stream an agent response for a module context.
+ * Returns an async generator of text chunks.
+ */
+export async function* streamModuleAgent(
+  ctx: ModuleContext,
+  agentType: string,
+  input: string,
+): AsyncGenerator<string> {
+  const res = await fetch(`${ctx.coreApiUrl}/api/v1/agents/ask`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${ctx.authToken}`,
+      'X-Module-Subdomain': ctx.moduleType.toLowerCase(),
+    },
+    body: JSON.stringify({
+      agentType,
+      input,
+      moduleSubdomain: ctx.moduleType.toLowerCase(),
+      stream: true,
+    }),
+  });
+
+  if (!res.ok || !res.body) return;
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    yield decoder.decode(value);
+  }
+}
+
+/**
+ * Get the chat context message for opening a module's agent chat.
+ * Used by "Talk to Agent" CTAs on module pages.
+ */
+export function getAgentChatHint(moduleType: string, entityContext?: string): string {
+  const hints: Record<string, string> = {
+    CRM: 'Help me manage my contacts and deals',
+    CONTENT_STUDIO: 'Help me create content or manage assets',
+    ANALYTICS: 'Show me my dashboard and key metrics',
+    SOCIAL_PUBLISHING: 'Help me schedule social media posts',
+    WORKFLOWS: 'Help me set up an automation workflow',
+    FINANCE: 'Help me with invoicing or budgets',
+    TIME_LEAVE: 'Help me log time or manage leave',
+    NPS: 'Help me create a survey',
+    LISTENING: 'Help me set up brand monitoring',
+    LMS: 'Help me create a course',
+    BOARDS: 'Help me set up a kanban board',
+  };
+
+  const base = hints[moduleType] || `Help me with ${moduleType}`;
+  return entityContext ? `${base}. Context: ${entityContext}` : base;
+}

--- a/sdk/index.ts
+++ b/sdk/index.ts
@@ -9,3 +9,10 @@ export * from "./types/index";
 export { ModuleInstaller } from "./installer/index";
 export { validateManifest } from "./validator/index";
 export { composeModule } from "./composer/index";
+
+// Phase 10C: Module factory, registration, discovery, hooks
+export { createModule, type ModuleOptions, type ModuleBundle } from "./factory/index";
+export { validateModuleConfig } from "./factory/validate";
+export { registerModule, deregisterModule, type RegistrationConfig, type RegistrationResult } from "./registration/index";
+export { discoverModules, buildModuleRegistry, getModulesForTier, type DiscoveredModule } from "./discovery/index";
+export { executeModuleAgent, streamModuleAgent, getAgentChatHint, type ModuleContext, type AgentResponse } from "./hooks/index";

--- a/sdk/registration/__tests__/registration.test.ts
+++ b/sdk/registration/__tests__/registration.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { registerModule, deregisterModule, type RegistrationConfig } from '../index';
+import type { ModuleManifest, AgentDefinition } from '../../types/index';
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch as any;
+
+const config: RegistrationConfig = {
+  agentBuilderUrl: 'https://agent-builder.test',
+  agentSecret: 'test-secret',
+  coreUrl: 'https://core.test',
+  coreAuthToken: 'test-token',
+};
+
+const manifest: ModuleManifest = {
+  id: 'crm',
+  moduleType: 'CRM',
+  name: 'CRM',
+  version: '1.0.0',
+  description: 'Test',
+  category: 'ops',
+  minTier: 'PRO',
+  agentDefinition: { path: 'src/agent/crm-agent.ts', name: 'crm-agent' },
+  tools: ['createContact'],
+  surfaces: [],
+};
+
+const agent: AgentDefinition = {
+  name: 'crm-agent',
+  description: 'CRM Agent',
+  system_prompt: 'You are the CRM agent.',
+  tools: ['createContact'],
+};
+
+describe('registerModule', () => {
+  beforeEach(() => mockFetch.mockReset());
+
+  it('registers with core then agent-builder', async () => {
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => ({}) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+
+    const result = await registerModule(manifest, agent, 'org_001', config);
+    expect(result.registered).toBe(true);
+    expect(result.moduleType).toBe('CRM');
+    expect(result.error).toBeUndefined();
+
+    // Verify core called first with Bearer token
+    expect(mockFetch.mock.calls[0][0]).toBe('https://core.test/api/v1/modules/install');
+    expect(mockFetch.mock.calls[0][1].headers.Authorization).toBe('Bearer test-token');
+
+    // Verify agent-builder called with X-Agent-Secret
+    expect(mockFetch.mock.calls[1][0]).toBe('https://agent-builder.test/api/v1/core/modules/register');
+    expect(mockFetch.mock.calls[1][1].headers['X-Agent-Secret']).toBe('test-secret');
+
+    // Verify snake_case body
+    const body = JSON.parse(mockFetch.mock.calls[1][1].body);
+    expect(body.org_id).toBe('org_001');
+    expect(body.module_type).toBe('CRM');
+  });
+
+  it('fails when core rejects', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      json: async () => ({ error: 'Tier too low' }),
+    });
+
+    const result = await registerModule(manifest, agent, 'org_001', config);
+    expect(result.registered).toBe(false);
+    expect(result.error).toContain('Core');
+    expect(mockFetch).toHaveBeenCalledTimes(1); // Should NOT call agent-builder
+  });
+
+  it('partial success when agent-builder fails', async () => {
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => ({}) })
+      .mockResolvedValueOnce({ ok: false, status: 500, json: async () => ({}) });
+
+    const result = await registerModule(manifest, agent, 'org_001', config);
+    expect(result.registered).toBe(true);
+    expect(result.error).toContain('agent-builder');
+  });
+});
+
+describe('deregisterModule', () => {
+  beforeEach(() => mockFetch.mockReset());
+
+  it('calls DELETE on agent-builder then POST on core', async () => {
+    mockFetch
+      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce({ ok: true });
+
+    const result = await deregisterModule('CRM', 'org_001', config);
+    expect(result.registered).toBe(false);
+
+    // Agent-builder DELETE
+    expect(mockFetch.mock.calls[0][0]).toContain('/deregister');
+    expect(mockFetch.mock.calls[0][1].method).toBe('DELETE');
+
+    // Core uninstall
+    expect(mockFetch.mock.calls[1][0]).toBe('https://core.test/api/v1/modules/uninstall');
+  });
+});

--- a/sdk/registration/index.ts
+++ b/sdk/registration/index.ts
@@ -1,0 +1,132 @@
+/**
+ * Module Registration — registers/deregisters modules with ongoing_agent_builder.
+ *
+ * Uses X-Agent-Secret header (not Authorization: Bearer).
+ * Uses snake_case body fields per agent-builder convention.
+ * Uses DELETE for deregistration.
+ */
+
+import type { ModuleManifest, AgentDefinition } from '../types/index';
+
+export interface RegistrationConfig {
+  /** Base URL for ongoing_agent_builder */
+  agentBuilderUrl: string;
+  /** Secret for X-Agent-Secret header */
+  agentSecret: string;
+  /** Base URL for spokestack-core */
+  coreUrl: string;
+  /** Bearer token for core API */
+  coreAuthToken: string;
+}
+
+export interface RegistrationResult {
+  registered: boolean;
+  moduleType: string;
+  error?: string;
+}
+
+/**
+ * Register a module with both spokestack-core and agent-builder.
+ */
+export async function registerModule(
+  manifest: ModuleManifest,
+  agent: AgentDefinition,
+  orgId: string,
+  config: RegistrationConfig,
+): Promise<RegistrationResult> {
+  // Step 1: Register with spokestack-core (creates OrgModule)
+  try {
+    const coreRes = await fetch(`${config.coreUrl}/api/v1/modules/install`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${config.coreAuthToken}`,
+      },
+      body: JSON.stringify({
+        orgId,
+        moduleType: manifest.moduleType,
+      }),
+    });
+
+    if (!coreRes.ok) {
+      const err = await coreRes.json().catch(() => ({ error: `HTTP ${coreRes.status}` }));
+      return { registered: false, moduleType: manifest.moduleType, error: `Core: ${err.error || coreRes.status}` };
+    }
+  } catch (err) {
+    return { registered: false, moduleType: manifest.moduleType, error: `Core unreachable: ${(err as Error).message}` };
+  }
+
+  // Step 2: Register with agent-builder (snake_case body, X-Agent-Secret header)
+  try {
+    const agentRes = await fetch(`${config.agentBuilderUrl}/api/v1/core/modules/register`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Agent-Secret': config.agentSecret,
+      },
+      body: JSON.stringify({
+        org_id: orgId,
+        module_type: manifest.moduleType,
+        agent_definition: {
+          name: agent.name,
+          description: agent.description,
+          system_prompt: agent.system_prompt,
+          tools: agent.tools,
+        },
+      }),
+    });
+
+    if (!agentRes.ok) {
+      return { registered: true, moduleType: manifest.moduleType, error: 'Core registered but agent-builder failed' };
+    }
+  } catch {
+    return { registered: true, moduleType: manifest.moduleType, error: 'Core registered but agent-builder unreachable' };
+  }
+
+  return { registered: true, moduleType: manifest.moduleType };
+}
+
+/**
+ * Deregister a module from agent-builder and core.
+ */
+export async function deregisterModule(
+  moduleType: string,
+  orgId: string,
+  config: RegistrationConfig,
+): Promise<RegistrationResult> {
+  // Step 1: Deregister from agent-builder (DELETE endpoint)
+  try {
+    await fetch(
+      `${config.agentBuilderUrl}/api/v1/core/modules/${encodeURIComponent(orgId)}/${encodeURIComponent(moduleType)}/deregister`,
+      {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Agent-Secret': config.agentSecret,
+        },
+      },
+    );
+  } catch {
+    // Non-blocking — continue with core deregistration
+  }
+
+  // Step 2: Deactivate in core
+  try {
+    const res = await fetch(`${config.coreUrl}/api/v1/modules/uninstall`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${config.coreAuthToken}`,
+      },
+      body: JSON.stringify({ orgId, moduleType }),
+    });
+
+    if (!res.ok) {
+      return { registered: false, moduleType, error: `Core uninstall failed: ${res.status}` };
+    }
+  } catch (err) {
+    return { registered: false, moduleType, error: `Core unreachable: ${(err as Error).message}` };
+  }
+
+  return { registered: false, moduleType };
+}


### PR DESCRIPTION
## Module SDK additions (797 lines, 8 files)

- **createModule()** — single-object factory for ModuleBundle (manifest + agent + hooks)
- **registerModule() / deregisterModule()** — two-step registration (core Bearer + agent-builder X-Agent-Secret)
- **discoverModules()** — filesystem scan, buildModuleRegistry(), getModulesForTier()
- **executeModuleAgent() / streamModuleAgent()** — module-aware agent execution with X-Module-Subdomain header
- **validateModuleConfig()** — validation without Zod dependency
- 21 new tests, 276 total passing